### PR TITLE
fix:修复在某些网站样式被污染的问题

### DIFF
--- a/content.js
+++ b/content.js
@@ -42,8 +42,8 @@ if (window.self === window.top) {
       iframe.style.setProperty('position', 'fixed', 'important');
       iframe.style.setProperty('top', '0', 'important');
       iframe.style.setProperty('right', '0', 'important');
-      iframe.style.setProperty('left', 'unset', 'important');
-      iframe.style.setProperty('bottom', 'unset', 'important');
+      iframe.style.setProperty('left', 'auto', 'important');
+      iframe.style.setProperty('bottom', 'auto', 'important');
       iframe.style.setProperty('z-index', '9999999999999', 'important');
       iframe.style.setProperty('transform', 'translateX(420px)', 'important');
       iframe.style.setProperty('transition', 'all .4s', 'important');


### PR DESCRIPTION
修复在一些网站（如[https://threejs.org/](https://threejs.org/)）因iframe样式被污染导致的展示问题

![image](https://user-images.githubusercontent.com/23151576/99145982-af2c1980-26ae-11eb-8aee-f1c3b2671a57.png)
