### PR TITLE
fix: 绑定原生xhr属性

### DIFF
--- a/pageScripts/main.js
+++ b/pageScripts/main.js
@@ -480,6 +480,11 @@ window.addEventListener("message", function (event) {
   }
 
   if (ajax_interceptor_qoweifjqon.settings.ajaxInterceptor_switchOn) {
+    // https://github.com/YGYOOO/ajax-interceptor/issues/78
+    // https://github.com/YGYOOO/ajax-interceptor/issues/93
+    for (const k in ajax_tools_space.originalXHR) {
+      ajax_tools_space.myXHR[k] = ajax_tools_space.originalXHR[k]
+    }
     window.XMLHttpRequest = ajax_interceptor_qoweifjqon.myXHR
     window.fetch = ajax_interceptor_qoweifjqon.myFetch
   } else {


### PR DESCRIPTION
fix https://github.com/YGYOOO/ajax-interceptor/issues/78
fix https://github.com/YGYOOO/ajax-interceptor/issues/93

开启插件后未配置拦截有些网站正常功能不能正确展示, 如B站的登陆信息。由于原生XMLHttpRequest属性未匹配, 如果业务代码 判断了这些属性就会出bug。如图所示：
![image](https://github.com/YGYOOO/ajax-interceptor/assets/25600325/c2f0f245-c50e-46ee-b9d4-84b7757bf9db)
